### PR TITLE
6 create entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@ HELP.md
 .gradle
 build/
 !gradle/wrapper/gradle-wrapper.jar
+
 !**/src/main/**/build/
 !**/src/test/**/build/
-
+!**/src/main/java/com/gdsc/pikpet/entity/
 ### STS ###
 .apt_generated
 .classpath
@@ -23,8 +24,6 @@ bin/
 *.iml
 *.ipr
 out/
-!**/src/main/**/out/
-!**/src/main/**/entity/
 !**/src/main/**/out/
 !**/src/test/**/out/
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ bin/
 *.ipr
 out/
 !**/src/main/**/out/
+!**/src/main/**/entity/
+!**/src/main/**/out/
 !**/src/test/**/out/
 
 ### NetBeans ###

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-starter', version: '1.2.5.RELEASE'
-	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage'
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-gcp-storage', version: '1.2.5.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/gdsc/pikpet/controller/TestController.java
+++ b/src/main/java/com/gdsc/pikpet/controller/TestController.java
@@ -1,7 +1,13 @@
 package com.gdsc.pikpet.controller;
 
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.*;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
 
 @RestController
 public class TestController {
@@ -9,5 +15,30 @@ public class TestController {
     @GetMapping("/")
     public String test() {
         return "Hello World!";
+    }
+
+    @GetMapping("/testImage")
+    public String testImage() throws IOException {
+        String bucketName = "solution-challenge-bucket"; // Google Cloud Storage 버킷 이름
+        String imageName = "good.jpg"; // 업로드할 이미지 파일 이름
+
+        // 서비스 계정 키 파일 경로
+        String jsonPath = "/Users/dbswodyd00/Desktop/github/3rd-sc-ex5-pikpet-Backend/src/main/resources/soc.json";
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream(jsonPath));
+        Storage storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+        // StorageOptions 생성 (인증 정보 설정 필요)
+        Blob blob = storage.get("solution-challenge-bucket", "spring.png");
+        blob.downloadTo(Paths.get("TestImage"));
+
+
+        // test시 resource 필드에 이미지 필요
+        BlobInfo blobInfo =storage.create(
+                BlobInfo.newBuilder("solution-challenge-bucket", "springTest.png")
+                        .setContentType("png")
+                        .build(),
+                new FileInputStream("TestImage"));
+
+        // 업로드 성공 시 메시지 반환
+        return "이미지 다운로드 완료: " + blob.getName();
     }
 }

--- a/src/main/java/com/gdsc/pikpet/controller/TestController.java
+++ b/src/main/java/com/gdsc/pikpet/controller/TestController.java
@@ -23,7 +23,7 @@ public class TestController {
         String imageName = "good.jpg"; // 업로드할 이미지 파일 이름
 
         // 서비스 계정 키 파일 경로
-        String jsonPath = "/Users/dbswodyd00/Desktop/github/3rd-sc-ex5-pikpet-Backend/src/main/resources/soc.json";
+        String jsonPath = "";
         GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream(jsonPath));
         Storage storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
         // StorageOptions 생성 (인증 정보 설정 필요)
@@ -31,7 +31,7 @@ public class TestController {
         blob.downloadTo(Paths.get("TestImage"));
 
 
-        // test시 resource 필드에 이미지 필요
+        // test시 resource 필드에 이미지+json 필요
         BlobInfo blobInfo =storage.create(
                 BlobInfo.newBuilder("solution-challenge-bucket", "springTest.png")
                         .setContentType("png")

--- a/src/main/java/com/gdsc/pikpet/controller/TestController.java
+++ b/src/main/java/com/gdsc/pikpet/controller/TestController.java
@@ -11,6 +11,9 @@ import java.nio.file.Paths;
 
 @RestController
 public class TestController {
+    // Google Cloud Storage 버킷 이름
+    @Value("${application.bucket.name}") 
+    private String bucketName;
 
     @GetMapping("/")
     public String test() {
@@ -19,7 +22,6 @@ public class TestController {
 
     @GetMapping("/testImage")
     public String testImage() throws IOException {
-        String bucketName = "solution-challenge-bucket"; // Google Cloud Storage 버킷 이름
         String imageName = "good.jpg"; // 업로드할 이미지 파일 이름
 
         // 서비스 계정 키 파일 경로

--- a/src/main/java/com/gdsc/pikpet/entity/Animal.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Animal.java
@@ -1,0 +1,35 @@
+package com.gdsc.pikpet.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class Animal {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Setter private String imageUrl;
+    @Setter @Enumerated(EnumType.STRING) private AnimalType animalType;
+
+    @Setter private int age;
+    @Setter @Enumerated(EnumType.STRING) private Gender gender;
+
+    @Setter private String species;
+    @Setter @Enumerated(EnumType.STRING) private AnimalSize size;
+    @Setter private String disease;
+
+    @Setter @ManyToOne @JoinColumn(name = "shelterId") private Shelter shelter;
+    @Setter private boolean isNeutralized;
+    @Setter private boolean checkUp;
+
+    @Setter @CreatedDate @Column(nullable = false)
+    private LocalDateTime captureDate;
+
+    @Setter private LocalDateTime enthanasiaDate;
+    @Setter private String color;
+}

--- a/src/main/java/com/gdsc/pikpet/entity/Animal.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Animal.java
@@ -23,7 +23,7 @@ public class Animal {
     @Setter @Enumerated(EnumType.STRING) private AnimalSize size;
     @Setter private String disease;
 
-    @Setter @ManyToOne @JoinColumn(name = "shelterId") private Shelter shelter;
+    @Setter @ManyToOne @JoinColumn(name = "shelter_id") private Shelter shelter;
     @Setter private boolean isNeutralized;
     @Setter private boolean checkUp;
 

--- a/src/main/java/com/gdsc/pikpet/entity/Animal.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Animal.java
@@ -6,6 +6,7 @@ import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter
@@ -32,5 +33,6 @@ public class Animal {
     private LocalDateTime captureDate;
 
     @Setter private LocalDateTime enthanasiaDate;
-    @Setter private String color;
+
+    @Setter @ElementCollection(fetch = FetchType.LAZY,targetClass = String.class) private List<String> color;
 }

--- a/src/main/java/com/gdsc/pikpet/entity/Animal.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Animal.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 @Getter
 public class Animal {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, name = "animal_id")
     private int id;
 
     @Setter private String imageUrl;

--- a/src/main/java/com/gdsc/pikpet/entity/AnimalSize.java
+++ b/src/main/java/com/gdsc/pikpet/entity/AnimalSize.java
@@ -1,0 +1,5 @@
+package com.gdsc.pikpet.entity;
+
+public enum AnimalSize {
+    SMALL, MEDIUM, LARGE
+}

--- a/src/main/java/com/gdsc/pikpet/entity/AnimalType.java
+++ b/src/main/java/com/gdsc/pikpet/entity/AnimalType.java
@@ -1,0 +1,5 @@
+package com.gdsc.pikpet.entity;
+
+public enum AnimalType {
+    CAT, DOG, OTHER
+}

--- a/src/main/java/com/gdsc/pikpet/entity/Application.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Application.java
@@ -1,0 +1,29 @@
+package com.gdsc.pikpet.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Type;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Entity
+@Getter
+public class Application {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Column(nullable = false)
+    private int id;
+
+    @Setter @ManyToOne @JoinColumn(name = "userId")
+    private UserAccount userAccount;
+
+    @Setter @ManyToOne @JoinColumn(name = "animalId")
+    private Animal animal;
+
+    @CreatedDate @Column(nullable = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime date;
+
+    @Setter private String contents;
+}

--- a/src/main/java/com/gdsc/pikpet/entity/Application.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Application.java
@@ -16,10 +16,10 @@ public class Application {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Column(nullable = false)
     private int id;
 
-    @Setter @ManyToOne @JoinColumn(name = "userId")
+    @Setter @ManyToOne @JoinColumn(name = "user_id")
     private UserAccount userAccount;
 
-    @Setter @ManyToOne @JoinColumn(name = "animalId")
+    @Setter @ManyToOne @JoinColumn(name = "animal_id")
     private Animal animal;
 
     @CreatedDate @Column(nullable = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/main/java/com/gdsc/pikpet/entity/Application.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Application.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @Entity
 @Getter
 public class Application {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Column(nullable = false)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Column(nullable = false, name = "application_id")
     private int id;
 
     @Setter @ManyToOne @JoinColumn(name = "user_id")

--- a/src/main/java/com/gdsc/pikpet/entity/Description.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Description.java
@@ -10,7 +10,7 @@ public class Description {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Setter @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY) @JoinColumn(name = "animalId")
+    @Setter @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY) @JoinColumn(name = "animal_id")
     private Animal animal;
     @Setter private String content;
     @Setter private String name;

--- a/src/main/java/com/gdsc/pikpet/entity/Description.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Description.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Getter
 public class Description {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, name = "description_id")
     private int id;
 
     @Setter @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY) @JoinColumn(name = "animal_id")

--- a/src/main/java/com/gdsc/pikpet/entity/Description.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Description.java
@@ -1,0 +1,17 @@
+package com.gdsc.pikpet.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+public class Description {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Setter @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY) @JoinColumn(name = "animalId")
+    private Animal animal;
+    @Setter private String content;
+    @Setter private String name;
+}

--- a/src/main/java/com/gdsc/pikpet/entity/Gender.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Gender.java
@@ -1,0 +1,5 @@
+package com.gdsc.pikpet.entity;
+
+public enum Gender {
+    MALE,FEMALE,OTHER
+}

--- a/src/main/java/com/gdsc/pikpet/entity/SearchHistory.java
+++ b/src/main/java/com/gdsc/pikpet/entity/SearchHistory.java
@@ -1,0 +1,24 @@
+package com.gdsc.pikpet.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class SearchHistory {
+    @Id @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    private int id;
+
+    @Setter @ManyToOne @JoinColumn(name = "userId")
+    private UserAccount userAccount;
+
+    @Setter private String imageUrl;
+
+    @CreatedDate @Column(nullable = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime searchDate;
+}

--- a/src/main/java/com/gdsc/pikpet/entity/SearchHistory.java
+++ b/src/main/java/com/gdsc/pikpet/entity/SearchHistory.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 public class SearchHistory {
     @Id @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+    @Column(nullable = false, name = "search_history_id")
     private int id;
 
     @Setter @ManyToOne @JoinColumn(name = "user_id")

--- a/src/main/java/com/gdsc/pikpet/entity/SearchHistory.java
+++ b/src/main/java/com/gdsc/pikpet/entity/SearchHistory.java
@@ -14,7 +14,7 @@ public class SearchHistory {
     @Id @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
     private int id;
 
-    @Setter @ManyToOne @JoinColumn(name = "userId")
+    @Setter @ManyToOne @JoinColumn(name = "user_id")
     private UserAccount userAccount;
 
     @Setter private String imageUrl;

--- a/src/main/java/com/gdsc/pikpet/entity/Shelter.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Shelter.java
@@ -1,0 +1,20 @@
+package com.gdsc.pikpet.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+public class Shelter {
+    @Column(nullable = false)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int shelterId;
+
+    @Setter private double latitude;
+    @Setter private double longitude;
+    @Setter private String branchName;
+    @Setter private String contact;
+    // Todo: mangerID의 경우 리팩토링이 필요할 수 있음. OneToOne으로 연결시 문제 가능성. ManyToOne으로 변경 고려
+    @Setter private int managerId;
+}

--- a/src/main/java/com/gdsc/pikpet/entity/Shelter.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Shelter.java
@@ -3,6 +3,7 @@ package com.gdsc.pikpet.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.geo.Point;
 
 @Entity
 @Getter
@@ -11,10 +12,8 @@ public class Shelter {
     @Column(nullable = false, name = "shelter_id")
     private int id;
 
-    @Setter private double latitude;
-    @Setter private double longitude;
+    @Setter @Column(columnDefinition = "GEOMETRY") private Point location;
     @Setter private String branchName;
     @Setter private String contact;
     // Todo: mangerID의 경우 리팩토링이 필요할 수 있음. OneToOne으로 연결시 문제 가능성. ManyToOne으로 변경 고려
-    @Setter private int managerId;
 }

--- a/src/main/java/com/gdsc/pikpet/entity/Shelter.java
+++ b/src/main/java/com/gdsc/pikpet/entity/Shelter.java
@@ -7,9 +7,9 @@ import lombok.Setter;
 @Entity
 @Getter
 public class Shelter {
-    @Column(nullable = false)
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int shelterId;
+    @Column(nullable = false, name = "shelter_id")
+    private int id;
 
     @Setter private double latitude;
     @Setter private double longitude;

--- a/src/main/java/com/gdsc/pikpet/entity/UserAccount.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserAccount.java
@@ -1,0 +1,41 @@
+package com.gdsc.pikpet.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Entity
+public class UserAccount {
+
+    @Id @Column(nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int userId;
+
+    @Setter private String email;
+    @Setter @Column(length = 100, nullable = false) private String password;
+    @Setter private String phoneNumber;
+    @Setter private Gender gender;
+    @Setter private int age;
+    @Setter private String address;
+    @Setter private String job;
+    @Setter @Enumerated(EnumType.STRING) private UserRole userRole;
+
+    protected UserAccount(){};
+
+    private UserAccount(String email,String password,String phoneNumber,Gender gender,int age,String address,String job, UserRole userRole){
+        this.email = email;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
+        this.gender = gender;
+        this.age = age;
+        this.address = address;
+        this.job = job;
+        this.userRole = userRole;
+    }
+
+    public static UserAccount of(String email,String password){
+        return new UserAccount(email,password,null,null,0,null,null,UserRole.USER);
+    }
+
+}

--- a/src/main/java/com/gdsc/pikpet/entity/UserAccount.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserAccount.java
@@ -10,7 +10,7 @@ public class UserAccount {
 
     @Id @Column(nullable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int userId;
+    private int id;
 
     @Setter private String email;
     @Setter @Column(length = 100, nullable = false) private String password;

--- a/src/main/java/com/gdsc/pikpet/entity/UserAccount.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserAccount.java
@@ -21,6 +21,9 @@ public class UserAccount {
     @Setter private String job;
     @Setter @Enumerated(EnumType.STRING) private UserRole userRole;
 
+    @Setter @ManyToOne @JoinColumn(name = "shelter_id")
+    private Shelter shelter;
+
     protected UserAccount(){};
 
     private UserAccount(String email,String password,String phoneNumber,Gender gender,int age,String address,String job, UserRole userRole){

--- a/src/main/java/com/gdsc/pikpet/entity/UserLike.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserLike.java
@@ -13,6 +13,6 @@ public class UserLike {
     @Setter @ManyToOne @JoinColumn(name = "user_account_id")
     private UserAccount userAccount;
 
-    @Setter @ManyToOne @JoinColumn(name = "animalId")
+    @Setter @ManyToOne @JoinColumn(name = "animal_id")
     private Animal animal;
 }

--- a/src/main/java/com/gdsc/pikpet/entity/UserLike.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserLike.java
@@ -1,0 +1,18 @@
+package com.gdsc.pikpet.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+public class UserLike {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
+    @Setter @ManyToOne @JoinColumn(name = "userId")
+    private UserAccount userAccount;
+
+    @Setter @ManyToOne @JoinColumn(name = "animalId")
+    private Animal animal;
+}

--- a/src/main/java/com/gdsc/pikpet/entity/UserLike.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserLike.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Getter
 public class UserLike {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, name = "user_like_id")
     private int id;
 
     @Setter @ManyToOne @JoinColumn(name = "user_account_id")

--- a/src/main/java/com/gdsc/pikpet/entity/UserLike.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserLike.java
@@ -10,7 +10,7 @@ public class UserLike {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @Setter @ManyToOne @JoinColumn(name = "userId")
+    @Setter @ManyToOne @JoinColumn(name = "user_account_id")
     private UserAccount userAccount;
 
     @Setter @ManyToOne @JoinColumn(name = "animalId")

--- a/src/main/java/com/gdsc/pikpet/entity/UserRole.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserRole.java
@@ -1,0 +1,5 @@
+package com.gdsc.pikpet.entity;
+
+public enum UserRole {
+    USER, ADMIN, SHELLTER
+}

--- a/src/main/java/com/gdsc/pikpet/entity/UserRole.java
+++ b/src/main/java/com/gdsc/pikpet/entity/UserRole.java
@@ -1,5 +1,5 @@
 package com.gdsc.pikpet.entity;
 
 public enum UserRole {
-    USER, ADMIN, SHELLTER
+    USER, ADMIN, SHELTER
 }

--- a/src/main/java/com/gdsc/pikpet/repository/AnimalRepository.java
+++ b/src/main/java/com/gdsc/pikpet/repository/AnimalRepository.java
@@ -1,0 +1,9 @@
+package com.gdsc.pikpet.repository;
+
+import com.gdsc.pikpet.entity.Animal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface AnimalRepository extends JpaRepository<Animal, Long> {
+}

--- a/src/main/java/com/gdsc/pikpet/repository/ApplicationRepository.java
+++ b/src/main/java/com/gdsc/pikpet/repository/ApplicationRepository.java
@@ -1,0 +1,9 @@
+package com.gdsc.pikpet.repository;
+
+import com.gdsc.pikpet.entity.Application;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface ApplicationRepository extends JpaRepository<Application, Long> {
+}

--- a/src/main/java/com/gdsc/pikpet/repository/DescriptionRepository.java
+++ b/src/main/java/com/gdsc/pikpet/repository/DescriptionRepository.java
@@ -1,0 +1,9 @@
+package com.gdsc.pikpet.repository;
+
+import com.gdsc.pikpet.entity.Description;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface DescriptionRepository extends JpaRepository<Description, Long> {
+}

--- a/src/main/java/com/gdsc/pikpet/repository/LikeRepository.java
+++ b/src/main/java/com/gdsc/pikpet/repository/LikeRepository.java
@@ -1,0 +1,9 @@
+package com.gdsc.pikpet.repository;
+
+import com.gdsc.pikpet.entity.UserLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface LikeRepository extends JpaRepository<UserLike, Long> {
+}

--- a/src/main/java/com/gdsc/pikpet/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/gdsc/pikpet/repository/SearchHistoryRepository.java
@@ -1,0 +1,9 @@
+package com.gdsc.pikpet.repository;
+
+import com.gdsc.pikpet.entity.SearchHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+}

--- a/src/main/java/com/gdsc/pikpet/repository/ShelterRepository.java
+++ b/src/main/java/com/gdsc/pikpet/repository/ShelterRepository.java
@@ -1,0 +1,9 @@
+package com.gdsc.pikpet.repository;
+
+import com.gdsc.pikpet.entity.Shelter;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface ShelterRepository extends JpaRepository<Shelter, Integer> {
+}

--- a/src/main/java/com/gdsc/pikpet/repository/UserAccountRepository.java
+++ b/src/main/java/com/gdsc/pikpet/repository/UserAccountRepository.java
@@ -1,0 +1,9 @@
+package com.gdsc.pikpet.repository;
+
+import com.gdsc.pikpet.entity.UserAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+public interface UserAccountRepository extends JpaRepository<UserAccount, Integer> {
+}


### PR DESCRIPTION
# 주요사항
+ Shelter의 위도 경도 필드를 스프링에서 제공하는 Point 데이터 타입의 사용을 고려해볼 필요가 있습니다.
+ 간단한 api 테스트는 data-rest를 이용하여 테스트하였습니다.
+ hal-explorer를 사용하여 api를 확인할 수 있습니다. (localhost:8080/api 참조)
+ ERD에 따라  Shelter가 manager_id(외래키)를 가지는 것에 대해서 고려해볼 필요가 있습니다. 다(user)대일(shelter)에 따라 user에서 shelter를 관리하는 것을 고려해볼 필요가 있습니다. 
+ Animal과 descprition entity에 CascadeType.ALL이 존재합니다.
+ 원하는 필드만 Setter를 적용하기 위해 필드마다 @Setter를 개별적으로 적용합니다. 위의 이유로 PK값과 createDate 타입의 경우 setter가 존재하지 않습니다.
+ mysql에 존재하는 예약어 'like'를 피하기 위해 테이블명을 UserLike로 변경합니다. 
+ manytoone의 경우 기본 전략 Eager를 사용중입니다. 추후 논의 후 변경 가능성이 존재합니다.

## 구현 목록
- [x] User Entity 구현
- [x] search-history 구현
- [x] like 구현
- [x] application 구현
- [x] shelter 구현
- [x] animal 구현
- [x] description 구현