### PR TITLE
#12 feat: Storage객체 생성

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 배포용 yml 파일 생성
+      # 배포용 yml 파일, gcs_key(json) 생성
       - name: make application.yml
         if: |
           contains(github.ref, 'main')
@@ -38,7 +38,9 @@ jobs:
           mkdir ./src/main/resources # resources 폴더 생성
           cd ./src/main/resources   
           touch ./application.yml #application.yml 생성
+          touch ./soc.json 
           echo "${{ secrets.YML }}" > ./application.yml # github actions에서 설정한 값을 application.yml 파일에 쓰기
+          echo "${{ secrets.GCS_KEY }}" > ./soc.json
         shell: bash
 
       # gradlew 권한 설정

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 .vscode/
 /src/main/resources/*.properties
 /src/main/resources/*.yml
+/src/main/resources/*.json

--- a/src/main/java/com/gdsc/pikpet/config/StorageConfig.java
+++ b/src/main/java/com/gdsc/pikpet/config/StorageConfig.java
@@ -1,0 +1,25 @@
+package com.gdsc.pikpet.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class StorageConfig {
+    // Google Cloud Storage json 경로
+    @Value("${gcs.json.path}")
+    private String jsonPath;
+
+    @Bean
+    public Storage googleStorage() throws IOException {
+        GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream(jsonPath));
+        Storage storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+        return storage;
+    }
+}

--- a/src/main/java/com/gdsc/pikpet/config/StorageConfig.java
+++ b/src/main/java/com/gdsc/pikpet/config/StorageConfig.java
@@ -4,7 +4,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/gdsc/pikpet/controller/TestController.java
+++ b/src/main/java/com/gdsc/pikpet/controller/TestController.java
@@ -1,7 +1,11 @@
 package com.gdsc.pikpet.controller;
 
+//import com.gdsc.pikpet.config.StorageConfig;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.storage.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,11 +14,12 @@ import java.io.IOException;
 import java.nio.file.Paths;
 
 @RestController
+@RequiredArgsConstructor
 public class TestController {
-    // Google Cloud Storage 버킷 이름
-    @Value("${application.bucket.name}") 
-    private String bucketName;
+    private final Storage storage;
 
+    @Value("${gcs.bucket.name}")
+    private String bucketName;
     @GetMapping("/")
     public String test() {
         return "Hello World!";
@@ -22,23 +27,16 @@ public class TestController {
 
     @GetMapping("/testImage")
     public String testImage() throws IOException {
-        String imageName = "good.jpg"; // 업로드할 이미지 파일 이름
-
-        // 서비스 계정 키 파일 경로
-        String jsonPath = "";
-        GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream(jsonPath));
-        Storage storage = StorageOptions.newBuilder().setCredentials(credentials).build().getService();
         // StorageOptions 생성 (인증 정보 설정 필요)
-        Blob blob = storage.get("solution-challenge-bucket", "spring.png");
-        blob.downloadTo(Paths.get("TestImage"));
-
+        Blob blob = storage.get(bucketName, "spring.png");
+        blob.downloadTo(Paths.get("TestImage.png"));
 
         // test시 resource 필드에 이미지+json 필요
         BlobInfo blobInfo =storage.create(
-                BlobInfo.newBuilder("solution-challenge-bucket", "springTest.png")
+                BlobInfo.newBuilder(bucketName, "springTest.png")
                         .setContentType("png")
                         .build(),
-                new FileInputStream("TestImage"));
+                new FileInputStream("TestImage.png"));
 
         // 업로드 성공 시 메시지 반환
         return "이미지 다운로드 완료: " + blob.getName();

--- a/src/main/java/com/gdsc/pikpet/controller/TestController.java
+++ b/src/main/java/com/gdsc/pikpet/controller/TestController.java
@@ -1,17 +1,17 @@
 package com.gdsc.pikpet.controller;
 
 //import com.gdsc.pikpet.config.StorageConfig;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.*;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
 
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Paths;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor


### PR DESCRIPTION
- google cloud에서 제공하는 Storage 객체를 빈으로 등록하여 사용하도록 변경
- 해당 json파일은 지정된 경로에 저장이 되어야 함. (application.yml에 적힌 경로)
- 추후 이미지를 저장하는 서비스 객체는 bucketName을 @Value로 가져오고, Storage를 주입받아서 사용하면 됨