### PR TITLE
#31 fix: Github Actions 폴더 생성 로직 삭제

### DIFF
--- a/.github/workflows/auto-deploy.yml
+++ b/.github/workflows/auto-deploy.yml
@@ -2,7 +2,7 @@ name: CI/CD using github actions & docker
 
 on:
   push:
-    branches: [ "main" ]
+#    branches: [ "main" ]
 
 jobs:
   auto-deploy:
@@ -33,7 +33,6 @@ jobs:
       # 배포용 yml 파일 생성
       - name: make application.yml
         run: |
-          mkdir ./src/main/resources # resources 폴더 생성
           cd ./src/main/resources   
           touch ./application.yml #application.yml 생성
           echo "${{ secrets.YML }}" > ./application.yml # github actions에서 설정한 값을 application.yml 파일에 쓰기


### PR DESCRIPTION
기존 template가 없었을 때, resources폴더가 없어서 Github Actions 내에서 폴더 생성을 했었음 하지만 template 파일이 생기면서 resources폴더도 생겼기 때문에 더이상 폴더 생성 로직을 사용할 필요가 없어짐